### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.9.10.4组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.seata.jit</groupId>
@@ -42,7 +40,7 @@
         <mysql-connector.version>5.1.44</mysql-connector.version>
         <curator.version>4.2.0</curator.version>
         <guava.version>27.0.1-jre</guava.version>
-        <jackson.version>2.9.10.4</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
         <druid.version>1.1.12</druid.version>
     </properties>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.9.10.4
漏洞编号：CVE-2020-35490
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML jackson-databind 2.x before 2.9.10.8 存在代码问题漏洞，该漏洞源于错误地处理了序列化小工具和类型之间的交互，这与org.apache.commons.dbcp2.datasources.PerUserPoolDataSource有关。
影响范围：(∞, 2.9.10.8)
最小修复版本：2.9.10.8
缺陷组件引入路径：io.seata.jit:jit@0.1.0-SNAPSHOT->io.seata:seata-server@1.2.0->io.seata:seata-config-all@1.2.0->io.seata:seata-config-nacos@1.2.0->com.alibaba.nacos:nacos-client@1.2.0->com.fasterxml.jackson.core:jackson-databind@2.9.10.4
```
另外我运行这个项目时，IDE的安全插件提示还有307个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p7b626